### PR TITLE
Image Caching Solution

### DIFF
--- a/Zane/cogs/image.py
+++ b/Zane/cogs/image.py
@@ -18,6 +18,8 @@ class Imaging:
 
     def __init__(self, bot):
         self.bot = bot
+        
+        # this is here so i can creat the pr without adding code. this will be removed when i commit the things that actually matter.
 
     async def _image_function_on_link(self, link: str, image_function, *args):
         start = time.perf_counter()

--- a/Zane/main.py
+++ b/Zane/main.py
@@ -38,6 +38,7 @@ class Zane(commands.AutoShardedBot):
         ]
         self.color = discord.Color.blue().value
 
+        self.accept_commands = False
         self.init_time = datetime.datetime.utcnow()
         self.owner_ids = [217462890364403712, 455289384187592704]
         super().__init__(command_prefix=self.prefix)
@@ -63,6 +64,10 @@ class Zane(commands.AutoShardedBot):
     async def prefix(self, bot, message):
         return commands.when_mentioned_or(*self.prefixes)(bot, message)
 
+    async def on_message(self, message):
+        if self.accept_commands:
+            await commands.process_commands(message)
+    
     def run(self, token: str):
         for cog in self.bot_cogs:
             try:
@@ -92,7 +97,7 @@ Guild Count: {len(self.guilds)}
 User Count: {len(list(self.get_all_members()))}""")
         self.loop.create_task(self.set_status())
         self.app_info = await self.application_info()
-        await asyncio.sleep(120)
+        self.accept_commands = True
 
     async def is_owner(self, user):
         if user.id in self.owner_ids:


### PR DESCRIPTION
### Idea
Adding an image cache solution for the image commands. The theory is that as long as a member's avatar is the same, the output of an image command will be the same. Therefore, we can do it the first time they ask and then store it. Then when they change their avatar we will pop it from the dict, using the on_member_update event. I plan to add the methods pull_from_cache, add_to_cache, and is_in_cache.

### Execution
When a command is run, it will see if it is in the cache with is_in_cache then if not, it will produce the output, sent it, then store in cache. If not, it will skip image generation and send the store discord.File object.

### Future
Later on, I may add a way to flush all stored images to stored image files on logout and then load them back after starting. However, this would be difficult because we would need to also store their avatar url at the time of storage.